### PR TITLE
Remove deprecated functions and unused imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ pytest tests/test_finance.py -v
 | Module | Test File | Functions Covered |
 |--------|-----------|-------------------|
 | `utils.date` | `test_utils_date.py` | `np_dt_to_str`, `excel_date_to_np`, `datetime_to_str`, `time_delta_to_days` |
-| `utils.generic` | `test_utils_generic.py` | `average`, `difference`, `flatten_dict`, `dict ops`, `chunk_list`, `to_array`, `match`, `linear_bucketing`, `change_dict_keys` |
+| `utils.generic` | `test_utils_generic.py` | `average`, `difference`, `flatten_dict`, `change_dict_keys`, `dict_from_df_cols`, `to_array`, `match`, `linear_bucketing` |
 | `utils.lists` | `test_utils_lists.py` | `flatten`, `flatten_list`, `has_duplicates`, `all_unique`, `chunk`, `count_occurrences`, `list_as_comma_sep` |
 | `utils.dataframe` | `test_utils_dataframe.py` | `replace_underscores_df`, `drop_null_columns_df`, `compare_dataframe_col`, `reconcile_dataframes_numeric`, `return_reconciliation_summary_table`, `get_selected_column_names`, `concat_columns` |
 | `security_analysis.finance` | `test_finance.py` | `calculate_relative_return_from_array`, `calculate_security_returns` (all return types), `calculate_annual_return`, `calculate_annual_volatility`, `return_sharpe_ratio`, `return_sortino_ratio`, `return_information_ratio` |

--- a/aialpha/security_analysis/finance.py
+++ b/aialpha/security_analysis/finance.py
@@ -5,8 +5,6 @@ Utils specific for financial security data
 import numpy as np
 import pandas as pd
 
-from aialpha.utils.decorators import deprecated
-from aialpha.utils.date import excel_date_to_np
 
 
 def calculate_relative_return_from_array(a: np.array) -> np.array:
@@ -196,89 +194,6 @@ def return_sortino_ratio(security_prices: pd.DataFrame,
     sortino = (period_return.mean() - risk_free) / target_downside_dev
 
     return sortino
-
-
-@deprecated
-def clean_bloomberg_security_data(input_file):
-    """
-    Params:
-        inputFile: csv
-            Data starts on the third row in format date | float.
-            e.g.
-            TICKER      | (empty)    | (empty) | ...
-            "Date"      | "PX_LAST"  | (empty) | ...
-            DD/MM/YYYY  | float      | (empty) | ...
-    Read csv file with two columns from bloomberg one with the date, and the other with the price.
-
-    Returns:
-         data (dataframe): Melted dataframe
-    """
-
-    a = pd.read_csv(input_file, header=None)
-    a = a.copy()
-    product = a.iloc[0, 0]
-
-    data = a.iloc[2:, :]
-    data = data.copy()
-    data['product'] = product
-    data.columns = ['date', 'price', 'product']
-    data = data[['product', 'date', 'price']]
-    return data
-
-
-@deprecated
-def return_melted_df(input_file):
-    """
-    Read csv file with Bloomberg data (in format below with or without blank columns) and create
-    melted pivot format inputFile
-    bb ticker | (empty)         | bb ticker | (empty)
-    Date      | "PX_LAST"       | Date      | "PX_LAST"
-    dd/mm/yyyy| float           | dd/mm/yyyy| float
-
-    Returns:
-    Contract    | Date      | Price
-    xxxx        | dd/mm/yy  | ##.##
-    """
-
-    x = pd.read_csv(input_file, header=None, parse_dates=True)
-    x.dropna(axis=1, how='all', inplace=True)
-
-    if any(pd.DataFrame(x.iloc[1, :]).drop_duplicates() == ['Date', "PX_LAST"]):
-        x = x.copy(True)
-        if x.shape[1] % 2 == 0:
-            df = pd.DataFrame()
-            for i in range(0, x.shape[1], 2):
-                product = x.iloc[0, i]  # extract name of product/security
-                data = x.iloc[2:, i:i + 2]
-                data.dropna(inplace=True)
-                data.reset_index(drop=True, inplace=True)
-
-                data['product'] = product
-
-                data.columns = ['date', 'price', 'product']
-                # data['date'] = np.datetime64(data['date'])
-                dates = np.array(data['date'])
-
-                # create a mask to ensure that all entries have the correct date format,
-                # not just Excel serial numbers
-                res = []
-                for date in dates:
-                    res.append(len(date))
-                res = np.array(res)
-                mask = (res != 10)
-                corrected_dates = pd.to_datetime(
-                    excel_date_to_np(np.array(dates[mask], dtype='int32'))
-                ).strftime('%Y/%m/%d')
-                dates[mask] = corrected_dates
-                data['date'] = dates
-
-                data = data[['product', 'date', 'price']]
-                df = df.append(data)
-                return df
-        else:
-            print("Dataframe is not in the correct format")
-    else:
-        raise TypeError("The dataframe is not in the format expected with columns: [Date, PX_LAST]")
 
 
 if __name__ == '__main__':

--- a/aialpha/utils/generic.py
+++ b/aialpha/utils/generic.py
@@ -7,8 +7,7 @@ import datetime as dt
 import gzip
 import os
 import re
-from math import ceil
-from typing import Union, Iterable
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -243,20 +242,6 @@ def find(folder_path, pattern='.*', full_path=False, expect_one=True):
     return files
 
 
-def chunk_list(lst: Union[list, np.array], chunk_size: int) -> Iterable:
-    """Generator yielding successive chunk-sized chunks from l
-
-    Args:
-        lst: list/array to chunk
-        chunk_size: size of chunk
-
-    Returns:
-        The next chunk of n in len(l) - 1
-    """
-    for i in range(0, ceil(len(lst) / chunk_size)):
-        yield lst[i * chunk_size: i * chunk_size + chunk_size]
-
-
 def format_csv_commas(path: str) -> list:
     """ 
     Feed in filepath of CSV to be edited and returns List of cleaned data, replacing 
@@ -294,22 +279,6 @@ def flatten_dict(d: dict) -> dict:
                 yield key, value
 
     return dict(items())
-
-
-def return_dict_keys(dct: dict) -> list:
-    """Returns keys of a dict in a list
-    >>> return_dict_keys({'a':1, 'b':2, 'c':3})
-    """
-    return list(dct.keys())
-
-
-def return_dict_values(dct: dict) -> list:
-    """
-    Returns keys of a dict in a list
-    >>> return_dict_values({'a':1, 'b':2, 'c':3})
-    [1, 2, 3]
-    """
-    return list(dct.values())
 
 
 def change_dict_keys(in_dict: dict, text: str) -> dict:

--- a/tests/test_utils_generic.py
+++ b/tests/test_utils_generic.py
@@ -4,9 +4,9 @@ import unittest
 import numpy as np
 import pandas as pd
 
-from aialpha.utils.generic import (average, difference, flatten_dict, return_dict_keys,
-                                   return_dict_values, change_dict_keys, dict_from_df_cols,
-                                   convert_config_dates, chunk_list, to_array, match,
+from aialpha.utils.generic import (average, difference, flatten_dict,
+                                   change_dict_keys, dict_from_df_cols,
+                                   convert_config_dates, to_array, match,
                                    linear_bucketing)
 
 
@@ -38,16 +38,6 @@ class TestUtilsGeneric(unittest.TestCase):
             "Dict should've been flatten to have "
             "two sub keys on b level: more detail, second level")
 
-    def test_utils_return_dict_keys(self):
-        self.assertEqual(return_dict_keys(dct={'a': 1, 'b': 2, 'c': 3}),
-                         ['a', 'b', 'c'],
-                         "Should've returned ['a', 'b', 'c']")
-
-    def test_utils_return_dict_values(self):
-        self.assertEqual(return_dict_values(dct={'a': 1, 'b': 2, 'c': 3}),
-                         [1, 2, 3],
-                         "Should've returned [1,2,3]")
-
     def test_utils_change_dict_keys(self):
         self.assertEqual(change_dict_keys(in_dict={'a': [1], 'b': [2]}, text='test'),
                          {'test_a': [1], 'test_b': [2]},
@@ -71,13 +61,6 @@ class TestUtilsGeneric(unittest.TestCase):
             {'date_one': np.datetime64('2020-01-01'),
              'date_two': np.datetime64('2019-01-01'),
              'DATE': np.datetime64('2010-12-25')}
-        )
-
-    def test_chunk_list(self):
-        a = chunk_list(lst=np.arange(10), chunk_size=2)
-        np.testing.assert_array_equal(
-            next(a),
-            np.array([0, 1])
         )
 
     def test_to_array__list(self):


### PR DESCRIPTION
This PR removes deprecated and unused utility functions to clean up the codebase and reduce technical debt.

**Key changes:**

- **Removed deprecated functions from `aialpha/security_analysis/finance.py`:**
  - `clean_bloomberg_security_data()` - deprecated Bloomberg data cleaning function
  - `return_melted_df()` - deprecated data melting function for Bloomberg format
  - Removed unused imports: `deprecated` decorator and `excel_date_to_np`

- **Removed utility functions from `aialpha/utils/generic.py`:**
  - `chunk_list()` - generator for chunking lists/arrays
  - `return_dict_keys()` - wrapper around `dict.keys()`
  - `return_dict_values()` - wrapper around `dict.values()`
  - Removed unused import: `ceil` from math module

- **Updated test file `tests/test_utils_generic.py`:**
  - Removed imports for deleted functions
  - Removed corresponding unit tests: `test_utils_return_dict_keys()`, `test_utils_return_dict_values()`, `test_chunk_list()`

- **Updated documentation in `README.md`:**
  - Updated test coverage table to reflect removed functions

These functions were either deprecated, redundant wrappers around built-in Python functionality, or no longer used in the codebase. This cleanup improves code maintainability without affecting active functionality.

https://claude.ai/code/session_01GKArK8ZATvT86mu3KY8qew